### PR TITLE
Package LICENSE and NOTICE in sdists/wheels

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+fastembed-vectorstore
+Copyright 2025 Saurav Niraula
+
+This product includes software developed by Saurav Niraula
+(https://github.com/sauravniraula/fastembed-vectorstore).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,6 +9,7 @@ description = "In-memory vector store with fastembed"
 authors = [{ name = "sauravniraula", email = "developmentsaurav@gmail.com" }]
 readme = "README.md"
 license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
 keywords = ["fastembed", "vectorstore", "python", "embedding", "vector database", "similarity search"]
 requires-python = ">=3.8"
 dependencies = ["fastembed", "numpy"]


### PR DESCRIPTION
Fixes #3

- Adds `license-files = ["LICENSE", "NOTICE"]` so sdists/wheels carry the license text (setuptools bumped to >=77 for PEP 639 support).
- Adds a minimal `NOTICE` file (Apache-2.0 convention; conda-forge packaging asked for it) — feel free to adjust the wording.

Verified with `python -m build --sdist`: the tarball now contains both `LICENSE` and `NOTICE`. If the release process builds with `uv_build` (as 0.5.3 did), `license-files` works there the same way.
